### PR TITLE
fix: Resolve Vercel deployment errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "arabic-financial-management",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,5 +24,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "supabase"]
 }


### PR DESCRIPTION
This commit fixes two issues that were causing the Vercel deployment to fail:

1.  **`tsconfig.json`:** The `supabase` directory, which contains Deno-based Edge Functions, is now added to the `exclude` array. This prevents the Next.js build process from incorrectly trying to compile this code, which resolves the `Cannot find module 'https://esm.sh/...'` type error.

2.  **`package.json`:** Added `"type": "module"` to resolve the `MODULE_TYPELESS_PACKAGE_JSON` warning and ensure modern module handling.

These changes, combined with the previous fix of renaming `next.config.ts` to `next.config.js`, should result in a successful deployment.